### PR TITLE
Add optional fields in the orders to model other type of products

### DIFF
--- a/umei-openapi.json
+++ b/umei-openapi.json
@@ -1551,7 +1551,7 @@
           },
           "minimumAcceptanceQuantity": {
             "type": "number",
-            "description": "The minimum quantity (power or energy, MW) that should be selected in the order. If the market can not to accept at least this quantity, then the order will be fully rejected. This field is optional. This field will be used for block orders only. ",
+            "description": "The minimum quantity (power or energy, MW) that should be traded/filled in the order. If the market can not to accept at least this quantity, then the order will be fully rejected. This field is optional. This field will be used for block orders only. ",
             "format": "double",
             "nullable": true
           },
@@ -1569,7 +1569,7 @@
           }
         },
         "additionalProperties": true,
-        "description": "Order defining a quantity (power or energy) submitted (sell or buy) on a market (defined by a market ID) for a given time interval. The portfolio ID is required only for sell orders. The grid node ID is required for sell orders and buy orders unless it can be derived from the portfolio. The order can either be a step order (i.e. order with uniform/constant price without any constraint on the selectable quantity), a block order (i.e. order with uniform/constant price that can be selected only with a minimum quantity) or an interpolated curve (i.e. order described by a piecewise linear function of prices and quantities). "
+        "description": "Order defining a quantity (power or energy) submitted (sell or buy) on a market (defined by a market ID) for a given time interval. The portfolio ID is required only for sell orders. The grid node ID is required for sell orders and buy orders unless it can be derived from the portfolio. The order can either be a step order (i.e. order with uniform/constant price without any constraint on the selectable quantity), a block order (i.e. order with uniform/constant price that can be traded/filled only with a minimum quantity) or an interpolated curve (i.e. order described by a piecewise linear function of prices and quantities). "
       },
       "OrderSearchResult": {
         "type": "object",

--- a/umei-openapi.json
+++ b/umei-openapi.json
@@ -1527,7 +1527,7 @@
           },
           "points": {
             "type": "array",
-            "description": "The array of quantity-price points of the order. If the order is a curtailable block order (meaning that the price is uniform/constant whatever the quantity) then the array will contain only one value. On the other hand, the array will contain several values if the order is an interpolated order (meaning that different prices will be defined for different quantities). In that case, the first quantity must always be zero.",
+            "description": "The array of quantity-price points of the order. If the order is a fixed-price order (meaning that the price is uniform/constant whatever the quantity) then the array will contain only one value. On the other hand, the array will contain several values if the order is an interpolated order (meaning that different prices will be defined for different quantities). In that case, the first quantity must always be zero.",
             "items": {
               "$ref": "#/components/schemas/QuantityPricePoint"
             },
@@ -1554,25 +1554,25 @@
           }
         },
         "additionalProperties": true,
-        "description": "Order defining a quantity (power or energy) submitted (sell or buy) on a market (defined by a market ID) for a given time interval. The portfolio ID is required only for sell orders. The grid node ID is required for sell orders and buy orders unless it can be derived from the portfolio. The order can either be a curtailable block order (i.e. order with uniform/constant price that can be traded/filled only with a minimum quantity) or an interpolated order (i.e. order described by a piecewise linear function of prices and quantities). "
+        "description": "Order defining a quantity (power or energy) submitted (sell or buy) on a market (defined by a market ID) for a given time interval. The portfolio ID is required only for sell orders. The grid node id is required for sell orders and buy orders unless it can be derived from the portfolio. The order can either be a fixed-price order (i.e. order with uniform/constant price that can be traded/filled only with a minimum quantity) or an interpolated order (i.e. order described by a piecewise linear function described by a list of price-points (prices and quantities). "
       },
       "QuantityPricePoint": {
         "type": "object",
+        "description": "A price-quantity-point of an order. A non-empty set of quantity-price-points describe a piecewise linear mapping from quantity to price. ",
         "properties": {
           "quantity": {
             "type": "number",
-            "description": "An amount of power or energy offered/bidded in the order, the type of quantity (i.e. power or energy) being deduced from the market. For both quantities the unit is MW.  \r\n\r\nFor power, it denotes the max (in absolute terms) power\r\nconsumption/production in MW during the specified period.\r\n            \r\nFor energy, it denotes the energy available during the specified period. The unit is still MW, thus the length of the interval needs to be taken into account to calculate the actual energy consumption/production.",
+            "description": "An amount of power or energy offered/bid in the order, the type of quantity (i.e. power or energy) being deduced from the market. For both quantities the unit is MW.  \r\n\r\nFor power, it denotes the max (in absolute terms) power\r\nconsumption/production in MW during the specified period.\r\n            \r\nFor energy, it denotes the energy available during the specified period. The unit is still MW, thus the length of the interval needs to be taken into account to calculate the actual energy consumption/production.",
             "format": "double",
             "nullable": false
           },
           "unitPrice": {
             "type": "number",
-            "description": "The price per unit (currency/MWh) for the quantity offered/bidded in the order, the currency being deduced from the market.",
+            "description": "The price per unit (currency/MWh) for the quantity offered/bid in the order, the currency being deduced from the market.",
             "format": "double",
             "nullable": false
           }
-        },
-        "description": "The quantity and price of an order"
+        }
       },
       "OrderSearchResult": {
         "type": "object",

--- a/umei-openapi.json
+++ b/umei-openapi.json
@@ -1513,7 +1513,7 @@
               "Down"
             ],
             "type": "string",
-            "description": "Type of regulation of the order. 'Up' means an increase in available power (either increased production or reduced consumption) and 'Down' means an decrease in available power (either reduced production or increased consumption). ",
+            "description": "Type of regulation of the order. 'Up' means an increase in available power (either increased production or reduced consumption) and 'Down' means a decrease in available power (either reduced production or increased consumption). ",
             "nullable": true
           },
           "side": {
@@ -1525,15 +1525,33 @@
             "description": "Type of submission of the order (buy / sell)",
             "nullable": false
           },
-          "quantity": {
-            "type": "number",
-            "description": "The amount of power or energy of the order, the type of quantity (i.e. power or energy) being deduced from the market. For both quantities the unit is MW.  \r\n\r\nFor power, it denotes the max (in absolute terms) power\r\nconsumption/production in MW during the specified period.\r\n            \r\nFor energy, it denotes the energy available during the specified period. The unit is still MW, thus the length of the interval needs to be taken into account to calculate the actual energy consumption/production.",
-            "format": "double",
+          "quantities": {
+            "type": "array",
+            "description": "The array of quantities of the order. If the order is a step curve (meaning that the price is uniform/constant whatever the quantity) then the array will contain only one value. On the other hand, the array will contain several values if the order is an interpolated curve (meaning that different prices will be defined for different quantities). In that case, the first quantity must always be zero. The market platform will return an error if the size of the array of prices is different from the size of the array of quantities.",
+            "items": {
+              "type": "number",
+              "description": "An amount of power or energy offered/bidded in the order, the type of quantity (i.e. power or energy) being deduced from the market. For both quantities the unit is MW.  \r\n\r\nFor power, it denotes the max (in absolute terms) power\r\nconsumption/production in MW during the specified period.\r\n            \r\nFor energy, it denotes the energy available during the specified period. The unit is still MW, thus the length of the interval needs to be taken into account to calculate the actual energy consumption/production.",
+              "format": "double",
+              "nullable": false
+            },
+            "minItems": 1,
             "nullable": true
           },
-          "unitPrice": {
+          "unitPrices": {
+            "type": "array",
+            "description": "The array of prices of the order. If the order is a step curve (meaning that the price is uniform/constant whatever the quantity) then the array will contain only one value. On the other hand, the array will contain several values if the order is an interpolated curve (meaning that different prices will be defined for different quantities). In that case, the prices must be increasing for a sell order and decreasing for a buy order. The market platform will return an error if the size of the array of prices is different from the size of the array of quantities.",
+            "items": {
+              "type": "number",
+              "description": "The price per unit (currency/MWh) for the quantity offered/bidded in the order, the currency being deduced from the market.",
+              "format": "double",
+              "nullable": false
+            },
+            "minItems": 1,
+            "nullable": true
+          },
+          "minimumAcceptanceQuantity": {
             "type": "number",
-            "description": "The price pr unit (currency/MWh), the currency being deduced from the market.",
+            "description": "The minimum quantity (power or energy, MW) that should be selected in the order. If the market can not to accept at least this quantity, then the order will be fully rejected. This field is optional. This field will be used for block orders only. ",
             "format": "double",
             "nullable": true
           },
@@ -1551,7 +1569,7 @@
           }
         },
         "additionalProperties": true,
-        "description": "Order defining a quantity (power or energy) submitted (sell or buy) on a market (defined by a market ID) for a given time interval. The portfolio ID is required only for sell orders. The grid node ID is required for sell orders and buy orders unless it can be derived from the portfolio. "
+        "description": "Order defining a quantity (power or energy) submitted (sell or buy) on a market (defined by a market ID) for a given time interval. The portfolio ID is required only for sell orders. The grid node ID is required for sell orders and buy orders unless it can be derived from the portfolio. The order can either be a step order (i.e. order with uniform/constant price without any constraint on the selectable quantity), a block order (i.e. order with uniform/constant price that can be selected only with a minimum quantity) or an interpolated curve (i.e. order described by a piecewise linear function of prices and quantities). "
       },
       "OrderSearchResult": {
         "type": "object",

--- a/umei-openapi.json
+++ b/umei-openapi.json
@@ -1525,33 +1525,18 @@
             "description": "Type of submission of the order (buy / sell)",
             "nullable": false
           },
-          "quantities": {
+          "points": {
             "type": "array",
-            "description": "The array of quantities of the order. If the order is a curtailable block order (meaning that the price is uniform/constant whatever the quantity) then the array will contain only one value. On the other hand, the array will contain several values if the order is an interpolated order (meaning that different prices will be defined for different quantities). In that case, the first quantity must always be zero. The market platform will return an error if the size of the array of prices is different from the size of the array of quantities.",
+            "description": "The array of quantity-price points of the order. If the order is a curtailable block order (meaning that the price is uniform/constant whatever the quantity) then the array will contain only one value. On the other hand, the array will contain several values if the order is an interpolated order (meaning that different prices will be defined for different quantities). In that case, the first quantity must always be zero.",
             "items": {
-              "type": "number",
-              "description": "An amount of power or energy offered/bidded in the order, the type of quantity (i.e. power or energy) being deduced from the market. For both quantities the unit is MW.  \r\n\r\nFor power, it denotes the max (in absolute terms) power\r\nconsumption/production in MW during the specified period.\r\n            \r\nFor energy, it denotes the energy available during the specified period. The unit is still MW, thus the length of the interval needs to be taken into account to calculate the actual energy consumption/production.",
-              "format": "double",
-              "nullable": false
-            },
-            "minItems": 1,
-            "nullable": true
-          },
-          "unitPrices": {
-            "type": "array",
-            "description": "The array of prices of the order. If the order is a curtailable block order (meaning that the price is uniform/constant whatever the quantity) then the array will contain only one value. On the other hand, the array will contain several values if the order is an interpolated order (meaning that different prices will be defined for different quantities). In that case, the prices must be increasing for a sell order and decreasing for a buy order. The market platform will return an error if the size of the array of prices is different from the size of the array of quantities.",
-            "items": {
-              "type": "number",
-              "description": "The price per unit (currency/MWh) for the quantity offered/bidded in the order, the currency being deduced from the market.",
-              "format": "double",
-              "nullable": false
+              "$ref": "#/components/schemas/QuantityPricePoint"
             },
             "minItems": 1,
             "nullable": true
           },
           "minimumAcceptanceQuantity": {
             "type": "number",
-            "description": "The minimum quantity (power or energy, MW) that should be traded/filled in the order. If the market can not to accept at least this quantity, then the order will be fully rejected. This field is optional. This field will be used for curtailable block orders only. ",
+            "description": "The minimum quantity (power or energy, MW) that should be traded/filled in the order.",
             "format": "double",
             "nullable": true
           },
@@ -1570,6 +1555,24 @@
         },
         "additionalProperties": true,
         "description": "Order defining a quantity (power or energy) submitted (sell or buy) on a market (defined by a market ID) for a given time interval. The portfolio ID is required only for sell orders. The grid node ID is required for sell orders and buy orders unless it can be derived from the portfolio. The order can either be a curtailable block order (i.e. order with uniform/constant price that can be traded/filled only with a minimum quantity) or an interpolated order (i.e. order described by a piecewise linear function of prices and quantities). "
+      },
+      "QuantityPricePoint": {
+        "type": "object",
+        "properties": {
+          "quantity": {
+            "type": "number",
+            "description": "An amount of power or energy offered/bidded in the order, the type of quantity (i.e. power or energy) being deduced from the market. For both quantities the unit is MW.  \r\n\r\nFor power, it denotes the max (in absolute terms) power\r\nconsumption/production in MW during the specified period.\r\n            \r\nFor energy, it denotes the energy available during the specified period. The unit is still MW, thus the length of the interval needs to be taken into account to calculate the actual energy consumption/production.",
+            "format": "double",
+            "nullable": false
+          },
+          "unitPrice": {
+            "type": "number",
+            "description": "The price per unit (currency/MWh) for the quantity offered/bidded in the order, the currency being deduced from the market.",
+            "format": "double",
+            "nullable": false
+          }
+        },
+        "description": "The quantity and price of an order"
       },
       "OrderSearchResult": {
         "type": "object",

--- a/umei-openapi.json
+++ b/umei-openapi.json
@@ -1527,7 +1527,7 @@
           },
           "quantities": {
             "type": "array",
-            "description": "The array of quantities of the order. If the order is a simple fully curtailable order or a block order (meaning that the price is uniform/constant whatever the quantity) then the array will contain only one value. On the other hand, the array will contain several values if the order is an interpolated curve (meaning that different prices will be defined for different quantities). In that case, the first quantity must always be zero. The market platform will return an error if the size of the array of prices is different from the size of the array of quantities.",
+            "description": "The array of quantities of the order. If the order is a curtailable block order (meaning that the price is uniform/constant whatever the quantity) then the array will contain only one value. On the other hand, the array will contain several values if the order is an interpolated order (meaning that different prices will be defined for different quantities). In that case, the first quantity must always be zero. The market platform will return an error if the size of the array of prices is different from the size of the array of quantities.",
             "items": {
               "type": "number",
               "description": "An amount of power or energy offered/bidded in the order, the type of quantity (i.e. power or energy) being deduced from the market. For both quantities the unit is MW.  \r\n\r\nFor power, it denotes the max (in absolute terms) power\r\nconsumption/production in MW during the specified period.\r\n            \r\nFor energy, it denotes the energy available during the specified period. The unit is still MW, thus the length of the interval needs to be taken into account to calculate the actual energy consumption/production.",
@@ -1539,7 +1539,7 @@
           },
           "unitPrices": {
             "type": "array",
-            "description": "The array of prices of the order. If the order is a curtailable step order or curtailable block order (meaning that the price is uniform/constant whatever the quantity) then the array will contain only one value. On the other hand, the array will contain several values if the order is an interpolated curve (meaning that different prices will be defined for different quantities). In that case, the prices must be increasing for a sell order and decreasing for a buy order. The market platform will return an error if the size of the array of prices is different from the size of the array of quantities.",
+            "description": "The array of prices of the order. If the order is a curtailable block order (meaning that the price is uniform/constant whatever the quantity) then the array will contain only one value. On the other hand, the array will contain several values if the order is an interpolated order (meaning that different prices will be defined for different quantities). In that case, the prices must be increasing for a sell order and decreasing for a buy order. The market platform will return an error if the size of the array of prices is different from the size of the array of quantities.",
             "items": {
               "type": "number",
               "description": "The price per unit (currency/MWh) for the quantity offered/bidded in the order, the currency being deduced from the market.",
@@ -1551,7 +1551,7 @@
           },
           "minimumAcceptanceQuantity": {
             "type": "number",
-            "description": "The minimum quantity (power or energy, MW) that should be traded/filled in the order. If the market can not to accept at least this quantity, then the order will be fully rejected. This field is optional. This field will be used for block orders only. ",
+            "description": "The minimum quantity (power or energy, MW) that should be traded/filled in the order. If the market can not to accept at least this quantity, then the order will be fully rejected. This field is optional. This field will be used for curtailable block orders only. ",
             "format": "double",
             "nullable": true
           },
@@ -1569,7 +1569,7 @@
           }
         },
         "additionalProperties": true,
-        "description": "Order defining a quantity (power or energy) submitted (sell or buy) on a market (defined by a market ID) for a given time interval. The portfolio ID is required only for sell orders. The grid node ID is required for sell orders and buy orders unless it can be derived from the portfolio. The order can either be a simple fully curtailable order (i.e. order with uniform/constant price without any constraint on the selectable quantity), a curtailable block order (i.e. order with uniform/constant price that can be traded/filled only with a minimum quantity) or an interpolated curve (i.e. order described by a piecewise linear function of prices and quantities). "
+        "description": "Order defining a quantity (power or energy) submitted (sell or buy) on a market (defined by a market ID) for a given time interval. The portfolio ID is required only for sell orders. The grid node ID is required for sell orders and buy orders unless it can be derived from the portfolio. The order can either be a curtailable block order (i.e. order with uniform/constant price that can be traded/filled only with a minimum quantity) or an interpolated order (i.e. order described by a piecewise linear function of prices and quantities). "
       },
       "OrderSearchResult": {
         "type": "object",

--- a/umei-openapi.json
+++ b/umei-openapi.json
@@ -1474,7 +1474,7 @@
             "description": "Type of submission of the order (buy / sell)",
             "nullable": false
           },
-          "points": {
+          "pricePoints": {
             "type": "array",
             "description": "The array of quantity-price points of the order. If the order is a fixed-price order (meaning that the price is uniform/constant whatever the quantity) then the array will contain only one value. On the other hand, the array will contain several values if the order is an interpolated order (meaning that different prices will be defined for different quantities). In that case, the first quantity must always be zero.",
             "items": {

--- a/umei-openapi.json
+++ b/umei-openapi.json
@@ -1527,7 +1527,7 @@
           },
           "quantities": {
             "type": "array",
-            "description": "The array of quantities of the order. If the order is a step curve (meaning that the price is uniform/constant whatever the quantity) then the array will contain only one value. On the other hand, the array will contain several values if the order is an interpolated curve (meaning that different prices will be defined for different quantities). In that case, the first quantity must always be zero. The market platform will return an error if the size of the array of prices is different from the size of the array of quantities.",
+            "description": "The array of quantities of the order. If the order is a simple fully curtailable order or a block order (meaning that the price is uniform/constant whatever the quantity) then the array will contain only one value. On the other hand, the array will contain several values if the order is an interpolated curve (meaning that different prices will be defined for different quantities). In that case, the first quantity must always be zero. The market platform will return an error if the size of the array of prices is different from the size of the array of quantities.",
             "items": {
               "type": "number",
               "description": "An amount of power or energy offered/bidded in the order, the type of quantity (i.e. power or energy) being deduced from the market. For both quantities the unit is MW.  \r\n\r\nFor power, it denotes the max (in absolute terms) power\r\nconsumption/production in MW during the specified period.\r\n            \r\nFor energy, it denotes the energy available during the specified period. The unit is still MW, thus the length of the interval needs to be taken into account to calculate the actual energy consumption/production.",
@@ -1539,7 +1539,7 @@
           },
           "unitPrices": {
             "type": "array",
-            "description": "The array of prices of the order. If the order is a step curve (meaning that the price is uniform/constant whatever the quantity) then the array will contain only one value. On the other hand, the array will contain several values if the order is an interpolated curve (meaning that different prices will be defined for different quantities). In that case, the prices must be increasing for a sell order and decreasing for a buy order. The market platform will return an error if the size of the array of prices is different from the size of the array of quantities.",
+            "description": "The array of prices of the order. If the order is a curtailable step order or curtailable block order (meaning that the price is uniform/constant whatever the quantity) then the array will contain only one value. On the other hand, the array will contain several values if the order is an interpolated curve (meaning that different prices will be defined for different quantities). In that case, the prices must be increasing for a sell order and decreasing for a buy order. The market platform will return an error if the size of the array of prices is different from the size of the array of quantities.",
             "items": {
               "type": "number",
               "description": "The price per unit (currency/MWh) for the quantity offered/bidded in the order, the currency being deduced from the market.",
@@ -1569,7 +1569,7 @@
           }
         },
         "additionalProperties": true,
-        "description": "Order defining a quantity (power or energy) submitted (sell or buy) on a market (defined by a market ID) for a given time interval. The portfolio ID is required only for sell orders. The grid node ID is required for sell orders and buy orders unless it can be derived from the portfolio. The order can either be a step order (i.e. order with uniform/constant price without any constraint on the selectable quantity), a block order (i.e. order with uniform/constant price that can be traded/filled only with a minimum quantity) or an interpolated curve (i.e. order described by a piecewise linear function of prices and quantities). "
+        "description": "Order defining a quantity (power or energy) submitted (sell or buy) on a market (defined by a market ID) for a given time interval. The portfolio ID is required only for sell orders. The grid node ID is required for sell orders and buy orders unless it can be derived from the portfolio. The order can either be a simple fully curtailable order (i.e. order with uniform/constant price without any constraint on the selectable quantity), a curtailable block order (i.e. order with uniform/constant price that can be traded/filled only with a minimum quantity) or an interpolated curve (i.e. order described by a piecewise linear function of prices and quantities). "
       },
       "OrderSearchResult": {
         "type": "object",


### PR DESCRIPTION
Hello @narve ,
We need other types of orders for the Portuguese demo.
I have added optional fields in the API to model the new characteristics of those orders. 