### PR TITLE
add the concept of flexibility zone which is required for the Portuguese demo

### DIFF
--- a/glossary.md
+++ b/glossary.md
@@ -5,7 +5,7 @@
 
 **Asset:** In this context, an asset represents a physical or virtual device which 
 has power characteristics that can be controlled, thus providing flexibility. 
-Typically assets are either consumers (e.g. heating systems, factories) or producers
+Typically, assets are either consumers (e.g. heating systems, factories) or producers
 (e.g. renewable energy sources or traditional power plants), while some assets
 (e.g. batteries) can both produce and consume. 
 
@@ -21,8 +21,11 @@ Typically assets are either consumers (e.g. heating systems, factories) or produ
 
 **FSP:** Flexibility Service Provider, an entity offering flexible assets into a market.   
 
-**GridNode:** Zone of the electrical grid to which an asset portfolio is connected and on which 
-  trading happens. 
+**GridNode:** Physical node of the electrical grid to which an asset portfolio is connected and on which 
+  trading happens.
+
+**FlexibilityZone** Set of several portfolios where the DSO defines specific flexibility needs and sensitivities. 
+A flexibility zone does not correspond to a physical zone of the electrical grid. 
 
 **Interpolated orders:** Order with a non-uniform price, i.e. instead of having one single price independently of the accepted part of the order, the price is evolving with the quantity accepted. Available on N-Side auction market. 
 

--- a/glossary.md
+++ b/glossary.md
@@ -17,15 +17,15 @@ Typically, assets are either consumers (e.g. heating systems, factories) or prod
 
 **Fill-or-kill:** Type of order that is immediately matched. The order is either matched in full and then killed, or else it is killed and instantly removed. No partial matching is allowed. Available in NODES continuous market. Commonly abbreviated as FoK. 
 
+**FlexibilityZone** Set of several portfolios where the DSO defines specific flexibility needs and sensitivities.
+A flexibility zone does not necessarily correspond to a physical zone of the electrical grid.
+
 **FMO:** Flexible Market Operator, the operator of the platform hosting a market on which participants can trade flexibility. 
 
 **FSP:** Flexibility Service Provider, an entity offering flexible assets into a market.   
 
 **GridNode:** Physical node of the electrical grid to which an asset portfolio is connected and on which 
   trading happens.
-
-**FlexibilityZone** Set of several portfolios where the DSO defines specific flexibility needs and sensitivities. 
-A flexibility zone does not correspond to a physical zone of the electrical grid. 
 
 **Interpolated orders:** Order with a non-uniform price, i.e. instead of having one single price independently of the accepted part of the order, the price is evolving with the quantity accepted. Available on N-Side auction market. 
 

--- a/umei-openapi.json
+++ b/umei-openapi.json
@@ -1334,30 +1334,226 @@
         }
       }
     },
-    "/FlexibilityZones/portfolios": {
+    "/Clearings": {
+      "get": {
+        "tags": [
+          "Clearing"
+        ],
+        "summary": "List all clearings",
+        "operationId": "Clearing_Search",
+        "responses": {
+          "200": {
+            "description": "Clearing(s) successfully returned",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ClearingSearchResult"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/UnauthenticatedError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ForbiddenError"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Clearing"
+        ],
+        "summary": "Create a new clearing",
+        "operationId": "Clearing_Create",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Clearing"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Clearing successfully created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Clearing"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/UnauthenticatedError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ForbiddenError"
+          }
+        }
+      }
+    },
+    "/Clearings/{id}": {
+      "get": {
+        "tags": [
+          "Clearing"
+        ],
+        "summary": "Get an existing clearing by id",
+        "operationId": "Clearing_GetById",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Clearing successfully returned",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Clearing"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/UnauthenticatedError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ForbiddenError"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Clearing"
+        ],
+        "summary": "Update an existing clearing, or create if missing",
+        "operationId": "Clearing_Update",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Clearing"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Clearing successfully updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Clearing"
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "Clearing successfully created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Clearing"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/UnauthenticatedError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ForbiddenError"
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "Clearing"
+        ],
+        "summary": "Patch / partially update an existing clearing",
+        "operationId": "Clearing_Patch",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Clearing"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Clearing successfully updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Clearing"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/UnauthenticatedError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ForbiddenError"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Clearing"
+        ],
+        "summary": "Delete/Remove an existing clearing",
+        "operationId": "Clearing_Delete",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Clearing successfully deleted"
+          },
+          "401": {
+            "$ref": "#/components/responses/UnauthenticatedError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ForbiddenError"
+          }
+        }
+      }
+    },
+    "/FlexibilityZones/portfoliosAndClearing": {
       "get": {
         "tags": [
           "FlexibilityZone"
         ],
-        "summary": "List or search one or several flexibility zones(s) using a query. Only the list of portfolios contained in the zone is returned.",
+        "summary": "List all flexibility zones. Only the list of portfolios contained in the zone and the clearing associated to the zone are returned.",
         "operationId": "PartialFlexibilityZone_Search",
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/flexibilityZoneId"
-          },
-          {
-            "$ref": "#/components/parameters/portfolioId"
-          },
-          {
-            "$ref": "#/components/parameters/take"
-          },
-          {
-            "$ref": "#/components/parameters/skip"
-          },
-          {
-            "$ref": "#/components/parameters/orderBy"
-          }
-        ],
         "responses": {
           "200": {
             "description": "Flexibility zone(s) successfully returned",
@@ -1383,25 +1579,8 @@
         "tags": [
           "FlexibilityZone"
         ],
-        "summary": "List or search one or several flexibility zones(s) using a query",
+        "summary": "List all flexibility zones",
         "operationId": "FlexibilityZone_Search",
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/flexibilityZoneId"
-          },
-          {
-            "$ref": "#/components/parameters/portfolioId"
-          },
-          {
-            "$ref": "#/components/parameters/take"
-          },
-          {
-            "$ref": "#/components/parameters/skip"
-          },
-          {
-            "$ref": "#/components/parameters/orderBy"
-          }
-        ],
         "responses": {
           "200": {
             "description": "Flexibility zone(s) successfully returned",
@@ -1598,6 +1777,219 @@
         "responses": {
           "204": {
             "description": "Flexibility zone successfully deleted"
+          },
+          "401": {
+            "$ref": "#/components/responses/UnauthenticatedError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ForbiddenError"
+          }
+        }
+      }
+    },
+    "/FlexibilityZonesLists": {
+      "get": {
+        "tags": [
+          "List of FlexibilityZones"
+        ],
+        "summary": "List all list(s) of flexibility zones",
+        "operationId": "ListFlexibilityZones_Search",
+        "responses": {
+          "200": {
+            "description": "List(s) of flexibility zones successfully returned",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListFlexibilityZonesSearchResult"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/UnauthenticatedError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ForbiddenError"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "List of FlexibilityZones"
+        ],
+        "summary": "Create a new list of flexibility zones",
+        "operationId": "ListFlexibilityZones_Create",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ListFlexibilityZones"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "List of flexibility zones successfully created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListFlexibilityZones"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/UnauthenticatedError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ForbiddenError"
+          }
+        }
+      }
+    },
+    "/FlexibilityZonesLists/{id}": {
+      "get": {
+        "tags": [
+          "List of FlexibilityZones"
+        ],
+        "summary": "Get an existing list of flexibility zones by id",
+        "operationId": "ListFlexibilityZones_GetById",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of flexibility zones successfully returned",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListFlexibilityZones"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/UnauthenticatedError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ForbiddenError"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "List of FlexibilityZones"
+        ],
+        "summary": "Update an existing list of flexibility zones, or create if missing",
+        "operationId": "ListFlexibilityZones_Update",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ListFlexibilityZones"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "List of flexibility zones successfully updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListFlexibilityZones"
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "List of flexibility zones successfully created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListFlexibilityZones"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/UnauthenticatedError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ForbiddenError"
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "List of FlexibilityZones"
+        ],
+        "summary": "Patch / partially update an existing list of flexibility zones",
+        "operationId": "ListFlexibilityZones_Patch",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ListFlexibilityZones"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "List of flexibility zones successfully updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListFlexibilityZones"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/UnauthenticatedError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ForbiddenError"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "List of FlexibilityZones"
+        ],
+        "summary": "Delete/Remove an existing list of flexibility zones",
+        "operationId": "ListFlexibilityZones_Delete",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "List of flexibility zones successfully deleted"
           },
           "401": {
             "$ref": "#/components/responses/UnauthenticatedError"
@@ -2239,6 +2631,56 @@
         },
         "description": "Order defining a quantity (power or energy) submitted (sell or buy) on a market (defined by a market id) for a given time interval. The portfolio id is required for sell orders. The grid node id is required only for sell orders and buy orders unless it can be derived from the portfolio. The portfolio id and the grid node id are not required if flexibility zones are created by the DSO, but in that case the flexibility zone id is required instead. The order can either be a fixed-price order (i.e. order with uniform/constant price that can be traded/filled only with a minimum quantity) or an interpolated order (i.e. order described by a piecewise linear function described by a list of price-points (prices and quantities). "
       },
+      "Clearing": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Id of the clearing (should be unique)",
+            "nullable": true
+          },
+          "clearingTime": {
+            "type": "string",
+            "description": "The timestamp indicating the time at which the clearing will start. The orders submitted after this timestamp will not be participate to the clearing.",
+            "format": "date-time",
+            "nullable": true
+          },
+          "periodFrom": {
+            "type": "string",
+            "description": "The timestamp indicating the start of the interval for which this clearing applies.",
+            "format": "date-time",
+            "nullable": true
+          },
+          "periodTo": {
+            "type": "string",
+            "description": "The timestamp indicating the end of the interval for which this clearing applies.",
+            "format": "date-time",
+            "nullable": true
+          }
+        },
+        "description": "Clearing defined by a start time and a delivery time interval"
+      },
+      "ListFlexibilityZones": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Id of the list of flexibility zones (should be unique)",
+            "nullable": true
+          },
+          "flexibilityZoneIds": {
+            "type": "array",
+            "description": "The list of ids of the flexibility zones contained in the list",
+            "items": {
+              "type": "string",
+              "description": "Id of a flexibility zone contained in the list",
+              "nullable": false
+            },
+            "nullable": true
+          }
+        },
+        "description": "List of flexibility zones"
+      },
       "FlexibilityZone": {
         "type": "object",
         "properties": {
@@ -2270,9 +2712,14 @@
               "nullable": false
             },
             "nullable": true
+          },
+          "clearingId": {
+            "type": "string",
+            "description": "Reference to the clearing. An error will be returned if this clearing does not exist.",
+            "nullable": true
           }
         },
-        "description": "Flexibility zone defined by a sensitivity, a flexibility need and a list of portfolios"
+        "description": "Flexibility zone defined by a sensitivity, a flexibility need, a list of portfolios and a reference to a clearing"
       },
       "FlexibilityZonePartial": {
         "type": "object",
@@ -2290,6 +2737,11 @@
               "description": "Id of a portfolio contained in the flexibility zone",
               "nullable": false
             },
+            "nullable": true
+          },
+          "clearingId": {
+            "type": "string",
+            "description": "Reference to the clearing. An error will be returned if this clearing does not exist.",
             "nullable": true
           }
         },
@@ -2325,6 +2777,56 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/Order"
+            },
+            "nullable": true
+          },
+          "links": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Link"
+            },
+            "nullable": true,
+            "readOnly": true
+          }
+        }
+      },
+      "ClearingSearchResult": {
+        "type": "object",
+        "properties": {
+          "numberOfHits": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Clearing"
+            },
+            "nullable": true
+          },
+          "links": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Link"
+            },
+            "nullable": true,
+            "readOnly": true
+          }
+        }
+      },
+      "ListFlexibilityZonesSearchResult": {
+        "type": "object",
+        "properties": {
+          "numberOfHits": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ListFlexibilityZones"
             },
             "nullable": true
           },

--- a/umei-openapi.json
+++ b/umei-openapi.json
@@ -2420,7 +2420,7 @@
           },
           "sensitivity": {
             "type": "number",
-            "description": "Sensitivity of the flexibility zone. Must be provided only if another flexibility zone has the same equivalentPerimeterId as the current flexibility zone.",
+            "description": "Sensitivity of the flexibility zone. When two or more flexibility zones have the same equivalentPerimeterId, a different sensitivity has to be provided for each of them.",
             "format": "double",
             "minimum": 0.0,
             "maximum": 1.0,
@@ -2448,7 +2448,8 @@
             "nullable": true
           },
           "equivalentPerimeterId": {
-            "type": "string",
+            "type": "integer",
+            "format": "int32",
             "description": "Id of the equivalent parameter. Some flexibility zones can be considered as equivalent in terms of ability to solve the congestion. Equivalent flexibility zones must be defined with the same equivalentPerimeterId.",
             "nullable": true
           }

--- a/umei-openapi.json
+++ b/umei-openapi.json
@@ -1510,7 +1510,7 @@
         }
       }
     },
-    "/FlexibilityZones/portfoliosAndClearing": {
+    "/PartialFlexibilityZones": {
       "get": {
         "tags": [
           "FlexibilityZone"
@@ -1523,7 +1523,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/FlexibilityZonePartialSearchResult"
+                  "$ref": "#/components/schemas/PartialFlexibilityZoneSearchResult"
                 }
               }
             }
@@ -1740,219 +1740,6 @@
         "responses": {
           "204": {
             "description": "Flexibility zone successfully deleted"
-          },
-          "401": {
-            "$ref": "#/components/responses/UnauthenticatedError"
-          },
-          "403": {
-            "$ref": "#/components/responses/ForbiddenError"
-          }
-        }
-      }
-    },
-    "/FlexibilityZonesLists": {
-      "get": {
-        "tags": [
-          "List of FlexibilityZones"
-        ],
-        "summary": "List all list(s) of flexibility zones",
-        "operationId": "ListFlexibilityZones_Search",
-        "responses": {
-          "200": {
-            "description": "List(s) of flexibility zones successfully returned",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ListFlexibilityZonesSearchResult"
-                }
-              }
-            }
-          },
-          "401": {
-            "$ref": "#/components/responses/UnauthenticatedError"
-          },
-          "403": {
-            "$ref": "#/components/responses/ForbiddenError"
-          }
-        }
-      },
-      "post": {
-        "tags": [
-          "List of FlexibilityZones"
-        ],
-        "summary": "Create a new list of flexibility zones",
-        "operationId": "ListFlexibilityZones_Create",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ListFlexibilityZones"
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "List of flexibility zones successfully created",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ListFlexibilityZones"
-                }
-              }
-            }
-          },
-          "400": {
-            "$ref": "#/components/responses/ValidationError"
-          },
-          "401": {
-            "$ref": "#/components/responses/UnauthenticatedError"
-          },
-          "403": {
-            "$ref": "#/components/responses/ForbiddenError"
-          }
-        }
-      }
-    },
-    "/FlexibilityZonesLists/{id}": {
-      "get": {
-        "tags": [
-          "List of FlexibilityZones"
-        ],
-        "summary": "Get an existing list of flexibility zones by id",
-        "operationId": "ListFlexibilityZones_GetById",
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/id"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "List of flexibility zones successfully returned",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ListFlexibilityZones"
-                }
-              }
-            }
-          },
-          "401": {
-            "$ref": "#/components/responses/UnauthenticatedError"
-          },
-          "403": {
-            "$ref": "#/components/responses/ForbiddenError"
-          }
-        }
-      },
-      "put": {
-        "tags": [
-          "List of FlexibilityZones"
-        ],
-        "summary": "Update an existing list of flexibility zones, or create if missing",
-        "operationId": "ListFlexibilityZones_Update",
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/id"
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ListFlexibilityZones"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "List of flexibility zones successfully updated",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ListFlexibilityZones"
-                }
-              }
-            }
-          },
-          "201": {
-            "description": "List of flexibility zones successfully created",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ListFlexibilityZones"
-                }
-              }
-            }
-          },
-          "400": {
-            "$ref": "#/components/responses/ValidationError"
-          },
-          "401": {
-            "$ref": "#/components/responses/UnauthenticatedError"
-          },
-          "403": {
-            "$ref": "#/components/responses/ForbiddenError"
-          }
-        }
-      },
-      "patch": {
-        "tags": [
-          "List of FlexibilityZones"
-        ],
-        "summary": "Patch / partially update an existing list of flexibility zones",
-        "operationId": "ListFlexibilityZones_Patch",
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/id"
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ListFlexibilityZones"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "List of flexibility zones successfully updated",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ListFlexibilityZones"
-                }
-              }
-            }
-          },
-          "400": {
-            "$ref": "#/components/responses/ValidationError"
-          },
-          "401": {
-            "$ref": "#/components/responses/UnauthenticatedError"
-          },
-          "403": {
-            "$ref": "#/components/responses/ForbiddenError"
-          }
-        }
-      },
-      "delete": {
-        "tags": [
-          "List of FlexibilityZones"
-        ],
-        "summary": "Delete/Remove an existing list of flexibility zones",
-        "operationId": "ListFlexibilityZones_Delete",
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/id"
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "List of flexibility zones successfully deleted"
           },
           "401": {
             "$ref": "#/components/responses/UnauthenticatedError"
@@ -2623,27 +2410,6 @@
         },
         "description": "Clearing defined by a start time and a delivery time interval"
       },
-      "ListFlexibilityZones": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string",
-            "description": "Id of the list of flexibility zones (should be unique)",
-            "nullable": true
-          },
-          "flexibilityZoneIds": {
-            "type": "array",
-            "description": "The list of ids of the flexibility zones contained in the list",
-            "items": {
-              "type": "string",
-              "description": "Id of a flexibility zone contained in the list",
-              "nullable": false
-            },
-            "nullable": true
-          }
-        },
-        "description": "List of flexibility zones"
-      },
       "FlexibilityZone": {
         "type": "object",
         "properties": {
@@ -2654,7 +2420,7 @@
           },
           "sensitivity": {
             "type": "number",
-            "description": "Sensitivity of the flexibility zone",
+            "description": "Sensitivity of the flexibility zone. Must be provided only if another flexibility zone has the same equivalentPerimeterId as the current flexibility zone.",
             "format": "double",
             "minimum": 0.0,
             "maximum": 1.0,
@@ -2680,11 +2446,16 @@
             "type": "string",
             "description": "Reference to the clearing. An error will be returned if this clearing does not exist.",
             "nullable": true
+          },
+          "equivalentPerimeterId": {
+            "type": "string",
+            "description": "Id of the equivalent parameter. Some flexibility zones can be considered as equivalent in terms of ability to solve the congestion. Equivalent flexibility zones must be defined with the same equivalentPerimeterId.",
+            "nullable": true
           }
         },
-        "description": "Flexibility zone defined by a sensitivity, a flexibility need, a list of portfolios and a reference to a clearing"
+        "description": "Flexibility zone defined by a sensitivity, a flexibility need, a list of portfolios, a reference to a clearing and a id allowing to define equivalent zones"
       },
-      "FlexibilityZonePartial": {
+      "PartialFlexibilityZone": {
         "type": "object",
         "properties": {
           "id": {
@@ -2778,31 +2549,6 @@
           }
         }
       },
-      "ListFlexibilityZonesSearchResult": {
-        "type": "object",
-        "properties": {
-          "numberOfHits": {
-            "type": "integer",
-            "format": "int32",
-            "nullable": true
-          },
-          "items": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/ListFlexibilityZones"
-            },
-            "nullable": true
-          },
-          "links": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Link"
-            },
-            "nullable": true,
-            "readOnly": true
-          }
-        }
-      },
       "FlexibilityZoneSearchResult": {
         "type": "object",
         "properties": {
@@ -2828,7 +2574,7 @@
           }
         }
       },
-      "FlexibilityZonePartialSearchResult": {
+      "PartialFlexibilityZoneSearchResult": {
         "type": "object",
         "properties": {
           "numberOfHits": {
@@ -2839,7 +2585,7 @@
           "items": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/FlexibilityZonePartial"
+              "$ref": "#/components/schemas/PartialFlexibilityZone"
             },
             "nullable": true
           },

--- a/umei-openapi.json
+++ b/umei-openapi.json
@@ -1235,6 +1235,9 @@
             "$ref": "#/components/parameters/portfolioId"
           },
           {
+            "$ref": "#/components/parameters/clearingId"
+          },
+          {
             "$ref": "#/components/parameters/status"
           },
           {
@@ -1899,6 +1902,15 @@
       "marketId": {
         "name": "marketId",
         "description": "Search by market id",
+        "in": "query",
+        "schema": {
+          "type": "string",
+          "nullable": true
+        }
+      },
+      "clearingId": {
+        "name": "clearingId",
+        "description": "Search by clearing id",
         "in": "query",
         "schema": {
           "type": "string",

--- a/umei-openapi.json
+++ b/umei-openapi.json
@@ -1235,9 +1235,6 @@
             "$ref": "#/components/parameters/portfolioId"
           },
           {
-            "$ref": "#/components/parameters/clearingId"
-          },
-          {
             "$ref": "#/components/parameters/status"
           },
           {
@@ -1300,226 +1297,54 @@
         }
       }
     },
-    "/Clearings": {
-      "get": {
-        "tags": [
-          "Clearing"
-        ],
-        "summary": "List all clearings",
-        "operationId": "Clearing_Search",
-        "responses": {
-          "200": {
-            "description": "Clearing(s) successfully returned",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ClearingSearchResult"
-                }
-              }
-            }
-          },
-          "401": {
-            "$ref": "#/components/responses/UnauthenticatedError"
-          },
-          "403": {
-            "$ref": "#/components/responses/ForbiddenError"
-          }
-        }
-      },
-      "post": {
-        "tags": [
-          "Clearing"
-        ],
-        "summary": "Create a new clearing",
-        "operationId": "Clearing_Create",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/Clearing"
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "Clearing successfully created",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Clearing"
-                }
-              }
-            }
-          },
-          "400": {
-            "$ref": "#/components/responses/ValidationError"
-          },
-          "401": {
-            "$ref": "#/components/responses/UnauthenticatedError"
-          },
-          "403": {
-            "$ref": "#/components/responses/ForbiddenError"
-          }
-        }
-      }
-    },
-    "/Clearings/{id}": {
-      "get": {
-        "tags": [
-          "Clearing"
-        ],
-        "summary": "Get an existing clearing by id",
-        "operationId": "Clearing_GetById",
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/id"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Clearing successfully returned",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Clearing"
-                }
-              }
-            }
-          },
-          "401": {
-            "$ref": "#/components/responses/UnauthenticatedError"
-          },
-          "403": {
-            "$ref": "#/components/responses/ForbiddenError"
-          }
-        }
-      },
-      "put": {
-        "tags": [
-          "Clearing"
-        ],
-        "summary": "Update an existing clearing, or create if missing",
-        "operationId": "Clearing_Update",
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/id"
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/Clearing"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Clearing successfully updated",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Clearing"
-                }
-              }
-            }
-          },
-          "201": {
-            "description": "Clearing successfully created",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Clearing"
-                }
-              }
-            }
-          },
-          "400": {
-            "$ref": "#/components/responses/ValidationError"
-          },
-          "401": {
-            "$ref": "#/components/responses/UnauthenticatedError"
-          },
-          "403": {
-            "$ref": "#/components/responses/ForbiddenError"
-          }
-        }
-      },
-      "patch": {
-        "tags": [
-          "Clearing"
-        ],
-        "summary": "Patch / partially update an existing clearing",
-        "operationId": "Clearing_Patch",
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/id"
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/Clearing"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Clearing successfully updated",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Clearing"
-                }
-              }
-            }
-          },
-          "400": {
-            "$ref": "#/components/responses/ValidationError"
-          },
-          "401": {
-            "$ref": "#/components/responses/UnauthenticatedError"
-          },
-          "403": {
-            "$ref": "#/components/responses/ForbiddenError"
-          }
-        }
-      },
-      "delete": {
-        "tags": [
-          "Clearing"
-        ],
-        "summary": "Delete/Remove an existing clearing",
-        "operationId": "Clearing_Delete",
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/id"
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Clearing successfully deleted"
-          },
-          "401": {
-            "$ref": "#/components/responses/UnauthenticatedError"
-          },
-          "403": {
-            "$ref": "#/components/responses/ForbiddenError"
-          }
-        }
-      }
-    },
     "/PartialFlexibilityZones": {
       "get": {
         "tags": [
           "FlexibilityZone"
         ],
-        "summary": "List all flexibility zones. Only the list of portfolios contained in the zone and the clearing associated to the zone are returned.",
+        "summary": "List or search one or several flexibility zone(s) using a query. Only the list of portfolios contained in the zone and the time period associated to the zone are returned.",
         "operationId": "PartialFlexibilityZone_Search",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/take"
+          },
+          {
+            "$ref": "#/components/parameters/skip"
+          },
+          {
+            "$ref": "#/components/parameters/orderBy"
+          },
+          {
+            "$ref": "#/components/parameters/periodFrom"
+          },
+          {
+            "$ref": "#/components/parameters/periodFrom.lt"
+          },
+          {
+            "$ref": "#/components/parameters/periodFrom.lte"
+          },
+          {
+            "$ref": "#/components/parameters/periodFrom.gt"
+          },
+          {
+            "$ref": "#/components/parameters/periodFrom.gte"
+          },
+          {
+            "$ref": "#/components/parameters/periodTo"
+          },
+          {
+            "$ref": "#/components/parameters/periodTo.lt"
+          },
+          {
+            "$ref": "#/components/parameters/periodTo.lte"
+          },
+          {
+            "$ref": "#/components/parameters/periodTo.gt"
+          },
+          {
+            "$ref": "#/components/parameters/periodTo.gte"
+          }
+        ],
         "responses": {
           "200": {
             "description": "Flexibility zone(s) successfully returned",
@@ -1545,8 +1370,49 @@
         "tags": [
           "FlexibilityZone"
         ],
-        "summary": "List all flexibility zones",
+        "summary": "List or search one or several flexibility zone(s) using a query",
         "operationId": "FlexibilityZone_Search",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/take"
+          },
+          {
+            "$ref": "#/components/parameters/skip"
+          },
+          {
+            "$ref": "#/components/parameters/orderBy"
+          },
+          {
+            "$ref": "#/components/parameters/periodFrom"
+          },
+          {
+            "$ref": "#/components/parameters/periodFrom.lt"
+          },
+          {
+            "$ref": "#/components/parameters/periodFrom.lte"
+          },
+          {
+            "$ref": "#/components/parameters/periodFrom.gt"
+          },
+          {
+            "$ref": "#/components/parameters/periodFrom.gte"
+          },
+          {
+            "$ref": "#/components/parameters/periodTo"
+          },
+          {
+            "$ref": "#/components/parameters/periodTo.lt"
+          },
+          {
+            "$ref": "#/components/parameters/periodTo.lte"
+          },
+          {
+            "$ref": "#/components/parameters/periodTo.gt"
+          },
+          {
+            "$ref": "#/components/parameters/periodTo.gte"
+          }
+        ],
         "responses": {
           "200": {
             "description": "Flexibility zone(s) successfully returned",
@@ -1902,15 +1768,6 @@
       "marketId": {
         "name": "marketId",
         "description": "Search by market id",
-        "in": "query",
-        "schema": {
-          "type": "string",
-          "nullable": true
-        }
-      },
-      "clearingId": {
-        "name": "clearingId",
-        "description": "Search by clearing id",
         "in": "query",
         "schema": {
           "type": "string",
@@ -2393,35 +2250,6 @@
         },
         "description": "Order defining a quantity (power or energy) submitted (sell or buy) on a market (defined by a market id) for a given time interval. The portfolio id is required for sell orders. The grid node id is required only for sell orders and buy orders unless it can be derived from the portfolio. The portfolio id and the grid node id are not required if flexibility zones are created by the DSO, but in that case the flexibility zone id is required instead. The order can either be a fixed-price order (i.e. order with uniform/constant price that can be traded/filled only with a minimum quantity) or an interpolated order (i.e. order described by a piecewise linear function described by a list of price-points (prices and quantities). "
       },
-      "Clearing": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string",
-            "description": "Id of the clearing (should be unique)",
-            "nullable": true
-          },
-          "clearingTime": {
-            "type": "string",
-            "description": "The timestamp indicating the time at which the clearing will start. The orders submitted after this timestamp will not be participate to the clearing.",
-            "format": "date-time",
-            "nullable": true
-          },
-          "periodFrom": {
-            "type": "string",
-            "description": "The timestamp indicating the start of the interval for which this clearing applies.",
-            "format": "date-time",
-            "nullable": true
-          },
-          "periodTo": {
-            "type": "string",
-            "description": "The timestamp indicating the end of the interval for which this clearing applies.",
-            "format": "date-time",
-            "nullable": true
-          }
-        },
-        "description": "Clearing defined by a start time and a delivery time interval"
-      },
       "FlexibilityZone": {
         "type": "object",
         "properties": {
@@ -2436,6 +2264,18 @@
             "format": "double",
             "nullable": true
           },
+          "periodFrom": {
+            "type": "string",
+            "description": "The timestamp indicating the start of the interval for which this flexibility need applies.",
+            "format": "date-time",
+            "nullable": true
+          },
+          "periodTo": {
+            "type": "string",
+            "description": "The timestamp indicating the end of the interval for which this flexibility need applies.",
+            "format": "date-time",
+            "nullable": true
+          },
           "portfolioIds": {
             "type": "array",
             "description": "The list of ids of the portfolios contained in the flexibility zone",
@@ -2445,14 +2285,9 @@
               "nullable": false
             },
             "nullable": true
-          },
-          "clearingId": {
-            "type": "string",
-            "description": "Reference to the clearing. An error will be returned if this clearing does not exist.",
-            "nullable": true
           }
         },
-        "description": "Flexibility zone defined by a flexibility need, a list of portfolios and a reference to a clearing"
+        "description": "Flexibility zone defined by a flexibility need, a time period and a list of portfolios"
       },
       "PartialFlexibilityZone": {
         "type": "object",
@@ -2462,6 +2297,18 @@
             "description": "Id of the flexibility zone (should be unique)",
             "nullable": true
           },
+          "periodFrom": {
+            "type": "string",
+            "description": "The timestamp indicating the start of the interval for which this flexibility need applies.",
+            "format": "date-time",
+            "nullable": true
+          },
+          "periodTo": {
+            "type": "string",
+            "description": "The timestamp indicating the end of the interval for which this flexibility need applies.",
+            "format": "date-time",
+            "nullable": true
+          },
           "portfolioIds": {
             "type": "array",
             "description": "The list of ids of the portfolios contained in the flexibility zone",
@@ -2471,14 +2318,9 @@
               "nullable": false
             },
             "nullable": true
-          },
-          "clearingId": {
-            "type": "string",
-            "description": "Reference to the clearing. An error will be returned if this clearing does not exist.",
-            "nullable": true
           }
         },
-        "description": "Flexibility zone defined by a list of portfolios"
+        "description": "Flexibility zone defined by a time period and a list of portfolios"
       },
       "QuantityPricePoint": {
         "type": "object",
@@ -2510,31 +2352,6 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/Order"
-            },
-            "nullable": true
-          },
-          "links": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Link"
-            },
-            "nullable": true,
-            "readOnly": true
-          }
-        }
-      },
-      "ClearingSearchResult": {
-        "type": "object",
-        "properties": {
-          "numberOfHits": {
-            "type": "integer",
-            "format": "int32",
-            "nullable": true
-          },
-          "items": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Clearing"
             },
             "nullable": true
           },

--- a/umei-openapi.json
+++ b/umei-openapi.json
@@ -1340,7 +1340,7 @@
           "FlexibilityZone"
         ],
         "summary": "List or search one or several flexibility zones(s) using a query. Only the list of portfolios contained in the zone is returned.",
-        "operationId": "FlexibilityZone_Search",
+        "operationId": "PartialFlexibilityZone_Search",
         "parameters": [
           {
             "$ref": "#/components/parameters/flexibilityZoneId"

--- a/umei-openapi.json
+++ b/umei-openapi.json
@@ -1295,43 +1295,6 @@
             "$ref": "#/components/responses/ForbiddenError"
           }
         }
-      },
-      "post": {
-        "tags": [
-          "Trade"
-        ],
-        "summary": "Create a new Trade",
-        "operationId": "Trade_Create",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/Trade"
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "Trade successfully created",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Trade"
-                }
-              }
-            }
-          },
-          "400": {
-            "$ref": "#/components/responses/ValidationError"
-          },
-          "401": {
-            "$ref": "#/components/responses/UnauthenticatedError"
-          },
-          "403": {
-            "$ref": "#/components/responses/ForbiddenError"
-          }
-        }
       }
     },
     "/Clearings": {

--- a/umei-openapi.json
+++ b/umei-openapi.json
@@ -2430,14 +2430,6 @@
             "description": "Id of the flexibility zone (should be unique)",
             "nullable": true
           },
-          "sensitivity": {
-            "type": "number",
-            "description": "Sensitivity of the flexibility zone. When two or more flexibility zones have the same equivalentPerimeterId, a different sensitivity has to be provided for each of them.",
-            "format": "double",
-            "minimum": 0.0,
-            "maximum": 1.0,
-            "nullable": true
-          },
           "flexibilityNeed": {
             "type": "number",
             "description": "An amount of power or energy needed in the zone, the type of quantity (i.e. power or energy) being deduced from the market. For both quantities the unit is MW.",
@@ -2458,15 +2450,9 @@
             "type": "string",
             "description": "Reference to the clearing. An error will be returned if this clearing does not exist.",
             "nullable": true
-          },
-          "equivalentPerimeterId": {
-            "type": "integer",
-            "format": "int32",
-            "description": "Id of the equivalent parameter. Some flexibility zones can be considered as equivalent in terms of ability to solve the congestion. Equivalent flexibility zones must be defined with the same equivalentPerimeterId.",
-            "nullable": true
           }
         },
-        "description": "Flexibility zone defined by a sensitivity, a flexibility need, a list of portfolios, a reference to a clearing and a id allowing to define equivalent zones"
+        "description": "Flexibility zone defined by a flexibility need, a list of portfolios and a reference to a clearing"
       },
       "PartialFlexibilityZone": {
         "type": "object",

--- a/umei-openapi.json
+++ b/umei-openapi.json
@@ -1149,7 +1149,7 @@
         "tags": [
           "Order"
         ],
-        "summary": "Patch / partially update an existing order",
+        "summary": "Patch / partially update an existing Order",
         "operationId": "Order_Patch",
         "parameters": [
           {
@@ -1287,6 +1287,43 @@
                 }
               }
             }
+          },
+          "401": {
+            "$ref": "#/components/responses/UnauthenticatedError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ForbiddenError"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Trade"
+        ],
+        "summary": "Create a new Trade",
+        "operationId": "Trade_Create",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Trade"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Trade successfully created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Trade"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
           },
           "401": {
             "$ref": "#/components/responses/UnauthenticatedError"

--- a/umei-openapi.json
+++ b/umei-openapi.json
@@ -23,6 +23,9 @@
             "$ref": "#/components/parameters/gridNodeId"
           },
           {
+            "$ref": "#/components/parameters/flexibilityZoneId"
+          },
+          {
             "$ref": "#/components/parameters/portfolioId"
           },
           {
@@ -951,6 +954,9 @@
             "$ref": "#/components/parameters/gridNodeId"
           },
           {
+            "$ref": "#/components/parameters/flexibilityZoneId"
+          },
+          {
             "$ref": "#/components/parameters/marketId"
           },
           {
@@ -1220,6 +1226,9 @@
             "$ref": "#/components/parameters/gridNodeId"
           },
           {
+            "$ref": "#/components/parameters/flexibilityZoneId"
+          },
+          {
             "$ref": "#/components/parameters/marketId"
           },
           {
@@ -1278,6 +1287,280 @@
                 }
               }
             }
+          },
+          "401": {
+            "$ref": "#/components/responses/UnauthenticatedError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ForbiddenError"
+          }
+        }
+      }
+    },
+    "/FlexibilityZones/portfolios": {
+      "get": {
+        "tags": [
+          "FlexibilityZone"
+        ],
+        "summary": "List or search one or several flexibility zones(s) using a query. Only the list of portfolios contained in the zone is returned.",
+        "operationId": "FlexibilityZone_Search",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/flexibilityZoneId"
+          },
+          {
+            "$ref": "#/components/parameters/portfolioId"
+          },
+          {
+            "$ref": "#/components/parameters/take"
+          },
+          {
+            "$ref": "#/components/parameters/skip"
+          },
+          {
+            "$ref": "#/components/parameters/orderBy"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Flexibility zone(s) successfully returned",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FlexibilityZonePartialSearchResult"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/UnauthenticatedError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ForbiddenError"
+          }
+        }
+      }
+    },
+    "/FlexibilityZones": {
+      "get": {
+        "tags": [
+          "FlexibilityZone"
+        ],
+        "summary": "List or search one or several flexibility zones(s) using a query",
+        "operationId": "FlexibilityZone_Search",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/flexibilityZoneId"
+          },
+          {
+            "$ref": "#/components/parameters/portfolioId"
+          },
+          {
+            "$ref": "#/components/parameters/take"
+          },
+          {
+            "$ref": "#/components/parameters/skip"
+          },
+          {
+            "$ref": "#/components/parameters/orderBy"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Flexibility zone(s) successfully returned",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FlexibilityZoneSearchResult"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/UnauthenticatedError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ForbiddenError"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "FlexibilityZone"
+        ],
+        "summary": "Create a new flexibility zone",
+        "operationId": "FlexibilityZone_Create",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FlexibilityZone"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Flexibility zone successfully created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FlexibilityZone"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/UnauthenticatedError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ForbiddenError"
+          }
+        }
+      }
+    },
+    "/FlexibilityZones/{id}": {
+      "get": {
+        "tags": [
+          "FlexibilityZone"
+        ],
+        "summary": "Get an existing flexibility zone by id",
+        "operationId": "FlexibilityZone_GetById",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Flexibility zone successfully returned",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FlexibilityZone"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/UnauthenticatedError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ForbiddenError"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "FlexibilityZone"
+        ],
+        "summary": "Update an existing flexibility zone, or create if missing",
+        "operationId": "FlexibilityZone_Update",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FlexibilityZone"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Flexibility zone successfully updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FlexibilityZone"
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "Flexibility zone successfully created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FlexibilityZone"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/UnauthenticatedError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ForbiddenError"
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "FlexibilityZone"
+        ],
+        "summary": "Patch / partially update an existing flexibility zone",
+        "operationId": "FlexibilityZone_Patch",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FlexibilityZone"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Flexibility zone successfully updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FlexibilityZone"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/UnauthenticatedError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ForbiddenError"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "FlexibilityZone"
+        ],
+        "summary": "Delete/Remove an existing flexibility zone",
+        "operationId": "FlexibilityZone_Delete",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/id"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Flexibility zone successfully deleted"
           },
           "401": {
             "$ref": "#/components/responses/UnauthenticatedError"
@@ -1392,6 +1675,15 @@
       "gridNodeId": {
         "name": "gridNodeId",
         "description": "Search by grid node id",
+        "in": "query",
+        "schema": {
+          "type": "string",
+          "nullable": true
+        }
+      },
+      "flexibilityZoneId": {
+        "name": "flexibilityZoneId",
+        "description": "Search by flexibility zone id",
         "in": "query",
         "schema": {
           "type": "string",
@@ -1693,7 +1985,7 @@
         "properties": {
           "id": {
             "type": "string",
-            "description": "The id of the market. This id will be used to define to which market an order belongs.",
+            "description": "Id of the market. This id will be used to define to which market an order belongs.",
             "nullable": false
           },
           "name": {
@@ -1842,6 +2134,11 @@
             "description": "The grid node this order applies to. An error will be returned if this grid node does not exist.",
             "nullable": true
           },
+          "flexibilityZoneId": {
+            "type": "string",
+            "description": "The flexibility zone this order applies to. An error will be returned if this flexibility zone does not exist.",
+            "nullable": true
+          },
           "marketId": {
             "type": "string",
             "description": "Reference to the market. An error will be returned if this market does not exist.",
@@ -1903,11 +2200,67 @@
             "nullable": true
           }
         },
-        "description": "Order defining a quantity (power or energy) submitted (sell or buy) on a market (defined by a market ID) for a given time interval. The portfolio ID is required only for sell orders. The grid node id is required for sell orders and buy orders unless it can be derived from the portfolio. The order can either be a fixed-price order (i.e. order with uniform/constant price that can be traded/filled only with a minimum quantity) or an interpolated order (i.e. order described by a piecewise linear function described by a list of price-points (prices and quantities). "
+        "description": "Order defining a quantity (power or energy) submitted (sell or buy) on a market (defined by a market id) for a given time interval. The portfolio id is required for sell orders. The grid node id is required only for sell orders and buy orders unless it can be derived from the portfolio. The portfolio id and the grid node id are not required if flexibility zones are created by the DSO, but in that case the flexibility zone id is required instead. The order can either be a fixed-price order (i.e. order with uniform/constant price that can be traded/filled only with a minimum quantity) or an interpolated order (i.e. order described by a piecewise linear function described by a list of price-points (prices and quantities). "
+      },
+      "FlexibilityZone": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Id of the flexibility zone (should be unique)",
+            "nullable": true
+          },
+          "sensitivity": {
+            "type": "number",
+            "description": "Sensitivity of the flexibility zone",
+            "format": "double",
+            "minimum": 0.0,
+            "maximum": 1.0,
+            "nullable": true
+          },
+          "flexibilityNeed": {
+            "type": "number",
+            "description": "An amount of power or energy needed in the zone, the type of quantity (i.e. power or energy) being deduced from the market. For both quantities the unit is MW.",
+            "format": "double",
+            "nullable": true
+          },
+          "portfolioIds": {
+            "type": "array",
+            "description": "The list of ids of the portfolios contained in the flexibility zone",
+            "items": {
+              "type": "string",
+              "description": "Id of a portfolio contained in the flexibility zone",
+              "nullable": false
+            },
+            "nullable": true
+          }
+        },
+        "description": "Flexibility zone defined by a sensitivity, a flexibility need and a list of portfolios"
+      },
+      "FlexibilityZonePartial": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Id of the flexibility zone (should be unique)",
+            "nullable": true
+          },
+          "portfolioIds": {
+            "type": "array",
+            "description": "The list of ids of the portfolios contained in the flexibility zone",
+            "items": {
+              "type": "string",
+              "description": "Id of a portfolio contained in the flexibility zone",
+              "nullable": false
+            },
+            "nullable": true
+          }
+        },
+        "description": "Flexibility zone defined by a list of portfolios"
       },
       "QuantityPricePoint": {
         "type": "object",
-        "description": "A price-quantity-point of an order. A non-empty set of quantity-price-points describe a piecewise linear mapping from quantity to price. ",
+        "description": "A price-quantity-point of an order. A non-empty set of quantity-price-points describes a piecewise linear mapping from quantity to price. ",
         "properties": {
           "quantity": {
             "type": "number",
@@ -1935,6 +2288,56 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/Order"
+            },
+            "nullable": true
+          },
+          "links": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Link"
+            },
+            "nullable": true,
+            "readOnly": true
+          }
+        }
+      },
+      "FlexibilityZoneSearchResult": {
+        "type": "object",
+        "properties": {
+          "numberOfHits": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FlexibilityZone"
+            },
+            "nullable": true
+          },
+          "links": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Link"
+            },
+            "nullable": true,
+            "readOnly": true
+          }
+        }
+      },
+      "FlexibilityZonePartialSearchResult": {
+        "type": "object",
+        "properties": {
+          "numberOfHits": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FlexibilityZonePartial"
             },
             "nullable": true
           },
@@ -2016,6 +2419,11 @@
           "gridNodeId": {
             "type": "string",
             "description": "Reference to the grid node.",
+            "nullable": true
+          },
+          "flexibilityZoneId": {
+            "type": "string",
+            "description": "Reference to the flexibility zone.",
             "nullable": true
           },
           "portfolioId": {

--- a/umei-openapi.json
+++ b/umei-openapi.json
@@ -1297,74 +1297,6 @@
         }
       }
     },
-    "/PartialFlexibilityZones": {
-      "get": {
-        "tags": [
-          "FlexibilityZone"
-        ],
-        "summary": "List or search one or several flexibility zone(s) using a query. Only the list of portfolios contained in the zone and the time period associated to the zone are returned.",
-        "operationId": "PartialFlexibilityZone_Search",
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/take"
-          },
-          {
-            "$ref": "#/components/parameters/skip"
-          },
-          {
-            "$ref": "#/components/parameters/orderBy"
-          },
-          {
-            "$ref": "#/components/parameters/periodFrom"
-          },
-          {
-            "$ref": "#/components/parameters/periodFrom.lt"
-          },
-          {
-            "$ref": "#/components/parameters/periodFrom.lte"
-          },
-          {
-            "$ref": "#/components/parameters/periodFrom.gt"
-          },
-          {
-            "$ref": "#/components/parameters/periodFrom.gte"
-          },
-          {
-            "$ref": "#/components/parameters/periodTo"
-          },
-          {
-            "$ref": "#/components/parameters/periodTo.lt"
-          },
-          {
-            "$ref": "#/components/parameters/periodTo.lte"
-          },
-          {
-            "$ref": "#/components/parameters/periodTo.gt"
-          },
-          {
-            "$ref": "#/components/parameters/periodTo.gte"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Flexibility zone(s) successfully returned",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PartialFlexibilityZoneSearchResult"
-                }
-              }
-            }
-          },
-          "401": {
-            "$ref": "#/components/responses/UnauthenticatedError"
-          },
-          "403": {
-            "$ref": "#/components/responses/ForbiddenError"
-          }
-        }
-      }
-    },
     "/FlexibilityZones": {
       "get": {
         "tags": [
@@ -2298,39 +2230,6 @@
         },
         "description": "Flexibility zone defined by a flexibility need, a time period and a list of portfolios"
       },
-      "PartialFlexibilityZone": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string",
-            "description": "Id of the flexibility zone (should be unique)",
-            "nullable": true
-          },
-          "periodFrom": {
-            "type": "string",
-            "description": "The timestamp indicating the start of the interval for which this flexibility need applies.",
-            "format": "date-time",
-            "nullable": true
-          },
-          "periodTo": {
-            "type": "string",
-            "description": "The timestamp indicating the end of the interval for which this flexibility need applies.",
-            "format": "date-time",
-            "nullable": true
-          },
-          "portfolioIds": {
-            "type": "array",
-            "description": "The list of ids of the portfolios contained in the flexibility zone",
-            "items": {
-              "type": "string",
-              "description": "Id of a portfolio contained in the flexibility zone",
-              "nullable": false
-            },
-            "nullable": true
-          }
-        },
-        "description": "Flexibility zone defined by a time period and a list of portfolios"
-      },
       "QuantityPricePoint": {
         "type": "object",
         "description": "A price-quantity-point of an order. A non-empty set of quantity-price-points describes a piecewise linear mapping from quantity to price. ",
@@ -2386,31 +2285,6 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/FlexibilityZone"
-            },
-            "nullable": true
-          },
-          "links": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Link"
-            },
-            "nullable": true,
-            "readOnly": true
-          }
-        }
-      },
-      "PartialFlexibilityZoneSearchResult": {
-        "type": "object",
-        "properties": {
-          "numberOfHits": {
-            "type": "integer",
-            "format": "int32",
-            "nullable": true
-          },
-          "items": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/PartialFlexibilityZone"
             },
             "nullable": true
           },


### PR DESCRIPTION
- A flexibility zone must contain:
    - an id
    - a sensitivity
    - a flexibility need
    - a list of portfolios
- Creation of new endpoints to create / get / update / delete the flexibility zones (should be only accessible to the DSO)
- Creation of a new endpoint to get only some information about the flexibility zone (i.e. the list of portfolios), because it's the only information that is visible to the aggregator
- Creation of a new endpoint to create a trade (so that the aggregator can create the trade of the disaggregated orders)
- Expected workflow:
     1. During the registration phase, the FSP will create portfolios for the different assets and indicate in which physical grid zone those assets are located, and post those portfolios on the market platform
     2. The DSO will get those portfolios
     3. The DSO will create several flexibility zones, i.e. groups of portfolios with different sensitivities and flexibility needs. Those flexibility zones do not correspond to a physical zone of the network (that's why we can't use the concept of grid node). The DSO will post those flexibility zones on the market platform
     4.  The aggregator will get the list of portfolios in each flexibility zone
     5. The aggregator will build an aggregated order for each zone, and post this order on the market platform (the order is associated to a flexibilityZoneId, no gridNodeId, no portfolioId)
     6. The market platform will launch the clearing
     7. The aggregator will get the trades of the aggregated order
     8. The aggregator will create the trades of the disaggregated orders and post them on the market platform
     9. The DSO will get the get the trades of the disaggregated orders