### PR TITLE
Revert "nullable query parameters"

### DIFF
--- a/umei-openapi.json
+++ b/umei-openapi.json
@@ -1796,8 +1796,7 @@
         "description": "Specify the \"periodFrom\" by exact match (with a resolution of one second)",
         "in": "query",
         "schema": {
-          "$ref": "#/components/schemas/TimeStamp",
-          "nullable": true
+          "$ref": "#/components/schemas/TimeStamp"
         }
       },
       "periodFrom.gt": {
@@ -1805,8 +1804,7 @@
         "description": "If specified, only return entries with a \"periodFrom\" that is greater (later) than this specified value. ",
         "in": "query",
         "schema": {
-          "$ref": "#/components/schemas/TimeStamp",
-          "nullable": true
+          "$ref": "#/components/schemas/TimeStamp"
         }
       },
       "periodFrom.gte": {
@@ -1814,8 +1812,7 @@
         "description": "If specified, only return entries with a \"periodFrom\" that is equal to (with a resolution of one second) or greater (later) than this specified value. ",
         "in": "query",
         "schema": {
-          "$ref": "#/components/schemas/TimeStamp",
-          "nullable": true
+          "$ref": "#/components/schemas/TimeStamp"
         }
       },
       "periodFrom.lt": {
@@ -1823,8 +1820,7 @@
         "description": "If specified, only return entries with a \"periodFrom\" smaller (earlier) than this specified value. ",
         "in": "query",
         "schema": {
-          "$ref": "#/components/schemas/TimeStamp",
-          "nullable": true
+          "$ref": "#/components/schemas/TimeStamp"
         }
       },
       "periodFrom.lte": {
@@ -1832,8 +1828,7 @@
         "description": "If specified, only return entries with a \"periodFrom\" smaller (earlier) than or equal to (with a resolution of one second) this specified value. ",
         "in": "query",
         "schema": {
-          "$ref": "#/components/schemas/TimeStamp",
-          "nullable": true
+          "$ref": "#/components/schemas/TimeStamp"
         }
       },
       "periodTo": {
@@ -1841,8 +1836,7 @@
         "description": "Specify the \"periodTo\" by exact match (with a resolution of one second)",
         "in": "query",
         "schema": {
-          "$ref": "#/components/schemas/TimeStamp",
-          "nullable": true
+          "$ref": "#/components/schemas/TimeStamp"
         }
       },
       "periodTo.gt": {
@@ -1850,8 +1844,7 @@
         "description": "If specified, only return entries with a \"periodTo\" that is greater (later) than this specified value. ",
         "in": "query",
         "schema": {
-          "$ref": "#/components/schemas/TimeStamp",
-          "nullable": true
+          "$ref": "#/components/schemas/TimeStamp"
         }
       },
       "periodTo.gte": {
@@ -1859,8 +1852,7 @@
         "description": "If specified, only return entries with a \"periodTo\" that is equal to (with a resolution of one second) or greater (later) than this specified value. ",
         "in": "query",
         "schema": {
-          "$ref": "#/components/schemas/TimeStamp",
-          "nullable": true
+          "$ref": "#/components/schemas/TimeStamp"
         }
       },
       "periodTo.lt": {
@@ -1868,8 +1860,7 @@
         "description": "If specified, only return entries with a \"periodTo\" smaller (earlier) than this specified value. ",
         "in": "query",
         "schema": {
-          "$ref": "#/components/schemas/TimeStamp",
-          "nullable": true
+          "$ref": "#/components/schemas/TimeStamp"
         }
       },
       "periodTo.lte": {
@@ -1877,8 +1868,7 @@
         "description": "If specified, only return entries with a \"periodTo\" smaller (earlier) than or equal to (with a resolution of one second) this specified value. ",
         "in": "query",
         "schema": {
-          "$ref": "#/components/schemas/TimeStamp",
-          "nullable": true
+          "$ref": "#/components/schemas/TimeStamp"
         }
       }
     },


### PR DESCRIPTION
Reverts euniversal/umei-api-specification#75

sorry, this was a bit rushed. I think the "nullable" parameter should be placed within the schema, not where it is now. At least I get validation warnings now. Can you check the spec and validate that it is actually legal? 