### PR TITLE
Add new error codes

### DIFF
--- a/error-codes.md
+++ b/error-codes.md
@@ -20,13 +20,21 @@ See the definition of the ProblemDetails object in the OpenAPI documentation for
 
 **InconsistentPeriods:** 'periodTo' must be subsequent to 'periodFrom'
 
+**InvalidBaseline** The baseline provided is not valid (input data validation error)
+
+**InvalidFlexibilityZone** The flexibility zone provided is not valid (input data validation error)
+
 **InvalidGridNode:** The given grid node does not exist, is not available for the current user, or is otherwise not available for the given order
 
 **InvalidLongflexContractId:** The given longflex contract does not exist, or is not available for the current user
 
 **InvalidMarket** The given market does not exist, is not available for the current user, or is otherwise not available for the given order
 
-**InvalidPortfolio:** The given portfolio does not exist, or is not available for the current user
+**InvalidMeterReading** The meter reading provided is not valid (input data validation error)
+
+**InvalidOrder** The order provided is not valid (input data validation error)
+
+**InvalidPortfolio:** The given portfolio is not valid (input data validation error), does not exist, or is not available for the current user
 
 **InvalidStatus:** The status specified is not valid for the item selected
 

--- a/umei-openapi.json
+++ b/umei-openapi.json
@@ -1097,7 +1097,7 @@
           "Order"
         ],
         "summary": "View publicly available order information",
-        "description": "This endpoint returns information about publicly visible flexibility orders. Publicly visible orders may contain less details then the information in an organizations own orders, in which case some fields will be empty. Different FMOs and different markets may have different rules regarding which information is pubilicy available. Each 'Order' returned in this endpoint represents either a single order, or multiple orders that have been aggregated together.  ",
+        "description": "This endpoint returns information about publicly visible flexibility orders. Publicly visible orders may contain less details then the information in an organizations own orders, in which case some fields will be empty. Different FMOs and different markets may have different rules regarding which information is publicly available. Each 'Order' returned in this endpoint represents either a single order, or multiple orders that have been aggregated together.  ",
         "operationId": "PublicOrder_Search",
         "parameters": [
           {
@@ -1899,7 +1899,7 @@
         }
       },
       "ForbiddenError": {
-        "description": "The server understands the request but refuses to authorize it (insufficient rights to a resource))",
+        "description": "The server understands the request but refuses to authorize it (insufficient rights to a resource)",
         "content": {
           "application/problem+json": {
             "schema": {
@@ -2813,7 +2813,7 @@
             "type": "string",
             "description": "A URI reference [RFC3986] that identifies the problem type. This specification encourages that, when de-referenced, it provide human-readable documentation for the problem type (e.g., using HTML [W3C.REC-html5-20141028]). When this member is not present, its value is assumed to be \"about:blank\"",
             "nullable": false,
-            "example": "https://umei.org/error-codes/invalid-grid-reference"
+            "example": "https://umei.org/error-codes/InvalidGridNode"
           },
           "title": {
             "type": "string",


### PR DESCRIPTION
Hello @narve 

I have added several new error codes.
They will be used when the user tries to post, put or patch a resource that is not valid.
Those new errors will be used in the "type" field of the "ProblemDetails" object of a "ValidationError".

Let's imagine that the user wants to create an order that contains two errors: "NonZeroFirstQuantity" and "InconsistentPeriods". In that case, we will return an "InvalidOrder" which is a bit more generic and we will describe both mistakes in the "validation-errors" list of the "ValidationError".

By the way, in our case we will not return a "NonZeroFirstQuantity" even if it's the only error found in the order (we will return an "InvalidOrder"). But it doesn't hurt keeping it in the UMEI